### PR TITLE
Fix checkout authentication

### DIFF
--- a/pages/api/stripe/[...nextstripe].ts
+++ b/pages/api/stripe/[...nextstripe].ts
@@ -1,5 +1,5 @@
 import NextStripe from "next-stripe";
 
 export default NextStripe({
-  secret_key: process.env.STRIPE_SECRET_KEY,
+  stripe_key: process.env.STRIPE_SECRET_KEY,
 });


### PR DESCRIPTION
In [...nextstripe].ts we should use `stripe_key` instead of `secret_key`. Otherwise the checkout authentication fails and we get 401 error.